### PR TITLE
Update Debian-Post-Install-Tasks_13172868.mdx re: haveged

### DIFF
--- a/docs/FreeSWITCH-Explained/Installation/Linux/Deprecated-Installation-Instructions/Debian-Post-Install-Tasks_13172868.mdx
+++ b/docs/FreeSWITCH-Explained/Installation/Linux/Deprecated-Installation-Instructions/Debian-Post-Install-Tasks_13172868.mdx
@@ -196,17 +196,18 @@ should be **uncommented** to preserve changes of /etc/resolv.conf.
 
 Debian systems running kernel versions prior to 5.6 may not have sufficient entropy for proper cryptography operations. **Haveged** is a userspace entropy daemon which is not dependent upon the standard mechanisms for harvesting randomness for the system entropy pool.  See Debian bugs [#999811](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=999811) and [#1034361](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1034361#12) for more information about the [haveged](https://tracker.debian.org/pkg/haveged) package.
 
+```bash
 apt -y install haveged   # installation  
 systemctl start haveged  # start  
 systemctl enable haveged # auto start
+```
 
 ## Automatic time synchronization
 
 **Chrony** is fast, secure and easy to use time synchronization daemon.
 
+```bash
 apt -y install chrony   # installation  
 systemctl start chrony  # start  
 systemctl enable chrony # auto start
-
-  
-
+```

--- a/docs/FreeSWITCH-Explained/Installation/Linux/Deprecated-Installation-Instructions/Debian-Post-Install-Tasks_13172868.mdx
+++ b/docs/FreeSWITCH-Explained/Installation/Linux/Deprecated-Installation-Instructions/Debian-Post-Install-Tasks_13172868.mdx
@@ -194,7 +194,7 @@ should be **uncommented** to preserve changes of /etc/resolv.conf.
 
 ## Proper entropy source
 
-Most of Debian systems may not have sufficient entropy for proper cryptography operations. **Haveged** is a userspace entropy daemon which is not dependent upon the standard mechanisms for harvesting randomness for the system entropy pool.
+Debian systems running kernel versions prior to 5.6 may not have sufficient entropy for proper cryptography operations. **Haveged** is a userspace entropy daemon which is not dependent upon the standard mechanisms for harvesting randomness for the system entropy pool.  See Debian bugs [#999811](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=999811) and [#1034361](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1034361#12) for more information about the [haveged](https://tracker.debian.org/pkg/haveged) package.
 
 apt -y install haveged   # installation  
 systemctl start haveged  # start  


### PR DESCRIPTION
Minor update to note that [haveged](https://tracker.debian.org/pkg/haveged) isn't needed on newer kernels.